### PR TITLE
Write an estimate how long it takes to load

### DIFF
--- a/binderhub/static/js/index.js
+++ b/binderhub/static/js/index.js
@@ -130,7 +130,7 @@ function build(providerSpec, log, path, pathType) {
 
   // Update the text of the loading page if it exists
   if ($('div#loader-text').length > 0) {
-    $('div#loader-text p').text("Loading repository: " + spec);
+    $('div#loader-text p').text("Loading repository (can take 30s or more to load): " + spec);
     window.setTimeout(function() {
       $('div#loader-text p').html("Repository " + spec + " is taking longer than usual to load, hang tight!")
     }, 120000);


### PR DESCRIPTION
It can take a long time to load the jupyter notebook. On average it takes about 30s for me. For new users who have never used Binder, it would be nice to give them some estimate what the expected waiting time is, so that they do not give up. This commit tries to do that.